### PR TITLE
feat: 数据库增加字段存储github用户信息

### DIFF
--- a/apps/api/src/user/model/user.dto.ts
+++ b/apps/api/src/user/model/user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, Length } from 'class-validator';
+import { IsNotEmpty, Length, IsString } from 'class-validator';
 
 export class CreateUserDto {
   @ApiProperty()
@@ -16,6 +16,22 @@ export class CreateUserDto {
   @IsNotEmpty({ message: '密码不能为空' })
   @Length(6, 20, { message: '密码长度为6-20位' })
   password: string;
+
+  @ApiProperty()
+  @IsString({ message: 'GitHub访问令牌必须是一个字符串' })
+  accessToken: string; // 新增GitHub访问令牌
+
+  @ApiProperty()
+  @IsString({ message: 'GitHub刷新令牌必须是一个字符串' })
+  refreshToken: string; // 新增GitHub刷新令牌
+
+  @ApiProperty()
+  @IsString({ message: 'GitHub用户ID必须是一个字符串' })
+  githubId: string; // 新增GitHub用户ID
+
+  @ApiProperty()
+  @IsString({ message: 'GitHub用户名必须是一个字符串' })
+  githubUsername: string; // 新增GitHub用户名
 }
 
 export class FindUserDto {
@@ -23,4 +39,8 @@ export class FindUserDto {
   @IsNotEmpty({ message: '手机号码不能为空' })
   @Length(6, 20, { message: '手机号码长度应在6到20位之间' })
   phone: string;
+
+  @ApiProperty()
+  @IsString({ message: 'GitHub用户ID必须是一个字符串' })
+  githubId: string; // 新增可选的GitHub用户ID
 }

--- a/packages/schema/src/schema/user.ts
+++ b/packages/schema/src/schema/user.ts
@@ -13,5 +13,8 @@ export const user = mysqlTable("users", {
   password: text("password").notNull(),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").onUpdateNow(),
-  
+  githubId: varchar("github_id", { length: 255 }), // 存储GitHub用户ID
+  githubAccessToken: text("github_access_token"), // 存储GitHub访问令牌
+  githubRefreshToken: text("github_refresh_token"), // 存储GitHub刷新令牌
+  githubUsername: varchar("github_username", { length: 255 }), // 存储GitHub用户名
 });


### PR DESCRIPTION
想数据库user表新增几个字段来存github登录的用户信息，咋没动静呢是不是我操作有误
1. docker:start
2. schema:build
3. db:init
![image](https://github.com/tonylawx/earthworm/assets/20318651/ba055852-9667-4d7f-981e-56ebb572755d)
